### PR TITLE
misra.py added argument to ignore rules

### DIFF
--- a/lib/astutils.h
+++ b/lib/astutils.h
@@ -77,6 +77,8 @@ bool isConstExpression(const Token *tok, const Library& library, bool pure);
 
 bool isWithoutSideEffects(bool cpp, const Token* tok);
 
+bool isUniqueExpression(const Token* tok);
+
 /** Is scope a return scope (scope will unconditionally return) */
 bool isReturnScope(const Token *endToken);
 

--- a/lib/checkother.cpp
+++ b/lib/checkother.cpp
@@ -1947,7 +1947,8 @@ void CheckOther::checkDuplicateExpression()
                         tok->next()->tokType() != Token::eType &&
                         tok->next()->tokType() != Token::eName &&
                         isSameExpression(_tokenizer->isCPP(), true, tok->next(), nextAssign->next(), _settings->library, true) &&
-                        isSameExpression(_tokenizer->isCPP(), true, tok->astOperand2(), nextAssign->astOperand2(), _settings->library, false)) {
+                        isSameExpression(_tokenizer->isCPP(), true, tok->astOperand2(), nextAssign->astOperand2(), _settings->library, false) &&
+                        !isUniqueExpression(tok->astOperand2())) {
                         duplicateAssignExpressionError(var1, var2);
                     }
                 }

--- a/lib/symboldatabase.cpp
+++ b/lib/symboldatabase.cpp
@@ -100,7 +100,7 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                                          tok->progressValue());
         // Locate next class
         if ((_tokenizer->isCPP() && ((Token::Match(tok, "class|struct|union|namespace ::| %name% {|:|::|<") &&
-                                      !Token::Match(tok->previous(), "new|friend|const|enum|)|(|<")) ||
+                                      !Token::Match(tok->previous(), "new|friend|const|enum|typedef|mutable|volatile|)|(|<")) ||
                                      (Token::Match(tok, "enum class| %name% {") ||
                                       Token::Match(tok, "enum class| %name% : %name% {"))))
             || (_tokenizer->isC() && Token::Match(tok, "struct|union|enum %name% {"))) {
@@ -143,9 +143,22 @@ void SymbolDatabase::createSymbolDatabaseFindAllScopes()
                     else if (Token::Match(tok2, "%name% ["))
                         continue;
                     // skip template
-                    else if (Token::Match(tok->previous(), "template class|struct") &&
-                             Token::simpleMatch(tok2->previous(), "> ;")) {
+                    else if (Token::simpleMatch(tok2, ";") &&
+                             Token::Match(tok->previous(), "template|> class|struct")) {
                         tok = tok2;
+                        continue;
+                    }
+                    // forward declaration
+                    else if (Token::simpleMatch(tok2, ";") &&
+                             Token::Match(tok, "class|struct|union")) {
+                        // TODO: see if it can be used
+                        tok = tok2;
+                        continue;
+                    }
+                    // skip constructor
+                    else if (Token::simpleMatch(tok2, "(") &&
+                             Token::simpleMatch(tok2->link(), ") ;")) {
+                        tok = tok2->link()->next();
                         continue;
                     } else
                         throw InternalError(tok2, "SymbolDatabase bailout; unhandled code", InternalError::SYNTAX);

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -133,6 +133,7 @@ private:
         TEST_CASE(duplicateExpressionTemplate); // #6930
         TEST_CASE(oppositeExpression);
         TEST_CASE(duplicateVarExpression);
+        TEST_CASE(duplicateVarExpressionUnique);
 
         TEST_CASE(checkSignOfUnsignedVariable);
         TEST_CASE(checkSignOfPointer);
@@ -3971,13 +3972,22 @@ private:
               "}");
         ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:3]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
-        check("struct Foo { int f() const; };\n"
+        check("struct Foo { int f() const; int g() const; };\n"
               "void test() {\n"
               "    Foo f = Foo{};\n"
               "    int i = f.f();\n"
               "    int j = f.f();\n"
               "}");
         ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
+
+        check("struct Foo { int f() const; int g() const; };\n"
+              "void test() {\n"
+              "    Foo f = Foo{};\n"
+              "    Foo f2 = Foo{};\n"
+              "    int i = f.f();\n"
+              "    int j = f.f();\n"
+              "}");
+        ASSERT_EQUALS("[test.cpp:6] -> [test.cpp:5]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
         check("int f() __attribute__((pure));\n"
               "void test() {\n"
@@ -3994,19 +4004,20 @@ private:
         ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:3]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
         check("int f(int) __attribute__((pure));\n"
+              "int g(int) __attribute__((pure));\n"
               "void test() {\n"
               "    int i = f(0);\n"
               "    int j = f(0);\n"
               "}");
-        ASSERT_EQUALS("[test.cpp:4] -> [test.cpp:3]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
+        ASSERT_EQUALS("[test.cpp:5] -> [test.cpp:4]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
-        check("void test(int * p) {\n"
+        check("void test(int * p, int * q) {\n"
               "    int i = *p;\n"
               "    int j = *p;\n"
               "}");
         ASSERT_EQUALS("[test.cpp:3] -> [test.cpp:2]: (style) Same expression used in consecutive assignments of 'i' and 'j'.\n", errout.str());
 
-        check("struct A { int x; };"
+        check("struct A { int x; int y; };"
               "void test(A a) {\n"
               "    int i = a.x;\n"
               "    int j = a.x;\n"
@@ -4080,6 +4091,50 @@ private:
         check("void test(int x) {\n"
               "    int i = x--;\n"
               "    int j = x--;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+    }
+
+    void duplicateVarExpressionUnique() {
+        check("struct SW { int first; };\n"
+              "void foo(SW* x) {\n"
+              "    int start = x->first;\n"
+              "    int end   = x->first;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+        check("struct SW { int first; };\n"
+              "void foo(SW* x, int i, int j) {\n"
+              "    int start = x->first;\n"
+              "    int end   = x->first;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+        check("struct Foo { int f() const; };\n"
+              "void test() {\n"
+              "    Foo f = Foo{};\n"
+              "    int i = f.f();\n"
+              "    int j = f.f();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("void test(int * p) {\n"
+              "    int i = *p;\n"
+              "    int j = *p;\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct Foo { int f() const; int g(int) const; };\n"
+              "void test() {\n"
+              "    Foo f = Foo{};\n"
+              "    int i = f.f();\n"
+              "    int j = f.f();\n"
+              "}");
+        ASSERT_EQUALS("", errout.str());
+
+        check("struct Foo { int f() const; };\n"
+              "void test() {\n"
+              "    Foo f = Foo{};\n"
+              "    int i = f.f();\n"
+              "    int j = f.f();\n"
               "}");
         ASSERT_EQUALS("", errout.str());
     }

--- a/test/testsymboldatabase.cpp
+++ b/test/testsymboldatabase.cpp
@@ -287,6 +287,7 @@ private:
         TEST_CASE(symboldatabase67); // #8538
         TEST_CASE(symboldatabase68); // #8560
         TEST_CASE(symboldatabase69);
+        TEST_CASE(symboldatabase70);
 
         TEST_CASE(enum1);
         TEST_CASE(enum2);
@@ -3893,6 +3894,27 @@ private:
         ASSERT(f && f->function() && f->function()->token->linenr() == 6);
         ASSERT(f && f->function() && !f->function()->isVolatile());
         ASSERT(f && f->function() && !f->function()->isConst());
+    }
+
+    void symboldatabase70() {
+        {
+            GET_SYMBOL_DB("class Map<String,Entry>::Entry* e;");
+            ASSERT(db != nullptr);
+            ASSERT(db && db->scopeList.size() == 1);
+            ASSERT(db && db->variableList().size() == 2);
+        }
+        {
+            GET_SYMBOL_DB("template class boost::token_iterator_generator<boost::offset_separator>::type; void foo() { }");
+            ASSERT(db != nullptr);
+            ASSERT(db && db->scopeList.size() == 2);
+        }
+        {
+            GET_SYMBOL_DB("void foo() {\n"
+                          "    return class Arm_relocate_functions<big_endian>::thumb32_branch_offset(upper_insn, lower_insn);\n"
+                          "}");
+            ASSERT(db != nullptr);
+            ASSERT(db && db->scopeList.size() == 2);
+        }
     }
 
     void enum1() {


### PR DESCRIPTION
Provide a comma-separated list of rules to ignore. For example
```bash
cppcheck --max-configs=1 --dump test/misra-test.c
python misra.py --rule-texts misra-texts.txt --ignore-rules 12.1,8.14 test/misra-test.c.dump
```

